### PR TITLE
Backport: replace deprecated ALooper_pollAll calls with pollOnce,  Disable implicit function declaration warning in microhttpd

### DIFF
--- a/modules/jetski/src/SurfaceThread.cpp
+++ b/modules/jetski/src/SurfaceThread.cpp
@@ -80,7 +80,10 @@ void* SurfaceThread::pthread_main(void* arg) {
                surfaceThread->message_callback, surfaceThread);
 
     while (surfaceThread->fRunning) {
-        const int ident = ALooper_pollAll(0, nullptr, nullptr, nullptr);
+        int ident = 0;
+        while (ident == ALOOPER_POLL_CALLBACK) {
+            ident = ALooper_pollOnce(0, nullptr, nullptr, nullptr);
+        }
 
         if (ident >= 0) {
             SkDebugf("Unhandled ALooper_pollAll ident=%d !", ident);

--- a/third_party/libmicrohttpd/BUILD.gn
+++ b/third_party/libmicrohttpd/BUILD.gn
@@ -26,6 +26,9 @@ third_party("libmicrohttpd") {
 
   defines = [ "DAUTH_SUPPORT=1" ]
   libs = []
+  if (is_clang) {
+    cflags = [ "-Wno-implicit-function-declaration" ]
+  }
 
   if (is_win) {
     sources += [ "../externals/microhttpd/src/platform/w32functions.c" ]

--- a/tools/sk_app/android/main_android.cpp
+++ b/tools/sk_app/android/main_android.cpp
@@ -38,28 +38,17 @@ void android_main(struct android_app* state) {
                                                            state));
 
     // loop waiting for stuff to do.
-    while (1) {
-        // Read all pending events.
-        int ident;
-        int events;
-        struct android_poll_source* source;
+    while (!state->destroyRequested) {
+        struct android_poll_source* source = nullptr;
+        auto result = ALooper_pollOnce(-1, nullptr, nullptr, (void**)&source);
 
-        // block forever waiting for events.
-        while ((ident=ALooper_pollAll(-1, nullptr, &events,
-                (void**)&source)) >= 0) {
-
-            // Process this event.
-            if (source != nullptr) {
-                source->process(state, source);
-            }
-
-            // Check if we are exiting.
-            if (state->destroyRequested != 0) {
-                return;
-            }
-
-            vkApp->onIdle();
+        if (result == ALOOPER_POLL_ERROR) {
+            SkDEBUGFAIL("ALooper_pollOnce returned an error");
         }
+        if (source != nullptr) {
+            source->process(state, source);
+        }
+        vkApp->onIdle();
     }
 }
 //END_INCLUDE(all)

--- a/tools/sk_app/android/surface_glue_android.cpp
+++ b/tools/sk_app/android/surface_glue_android.cpp
@@ -218,7 +218,10 @@ void* SkiaAndroidApp::pthread_main(void* arg) {
                                                skiaAndroidApp);
 
     while (true) {
-        const int ident = ALooper_pollAll(0, nullptr, nullptr, nullptr);
+        int ident = 0;
+        while (ident == ALOOPER_POLL_CALLBACK) {
+            ident = ALooper_pollOnce(0, nullptr, nullptr, nullptr);
+        }
 
         if (ident >= 0) {
             SkDebugf("Unhandled ALooper_pollAll ident=%d !", ident);


### PR DESCRIPTION
These patches fix build with Android NDK r27

Link: https://github.com/google/skia/commit/3b3b1edf5e43627ba9dce3383104e3c77508acf0
Link: https://github.com/google/skia/commit/f0a8c9fc88f8f69734ff26d5c364dcd542aea1f8